### PR TITLE
Switch from OpenAI to Gemini

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+GOOGLE_API_KEY=
+

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install -r requirements.txt
 4. 環境変数の設定：
 ```bash
 cp .env.example .env
-# .envファイルを編集し、OPENAI_API_KEY、GOOGLE_API_KEY、GOOGLE_CLI_IDを設定
+# .envファイルを編集し、GOOGLE_API_KEYを設定
 ```
 
 ## 使用方法
@@ -95,4 +95,4 @@ llm-baseball-swing-coach/
 ## 注意事項
 - このシステムはアシスタントとして機能することを目的としており、プロのコーチの判断を完全に代替するものではありません。
 - 動画分析には高性能なGPUを推奨します。
-- APIキーの利用には別途OpenAIのアカウントとクレジットが必要です。
+- Gemini APIを利用するにはGoogleのAPIキーが必要です。

--- a/agents/base.py
+++ b/agents/base.py
@@ -2,13 +2,13 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Dict, List, Any, Optional, Tuple, TypeVar
 
-from langchain_openai import ChatOpenAI
+from langchain_google_genai import ChatGoogleGenerativeAI
 from models.output.agent_output import AgentOutput
 from core.base.logger import SystemLogger
 
 
 class BaseAgent(ABC):
-    def __init__(self, llm: ChatOpenAI):
+    def __init__(self, llm: ChatGoogleGenerativeAI):
         self.llm = llm
         self.agent_name = self.__class__.__name__
         self.logger = SystemLogger()

--- a/agents/goal_setting_agent/agent.py
+++ b/agents/goal_setting_agent/agent.py
@@ -1,6 +1,6 @@
 import json
 from typing import Any, Dict, List
-from langchain_openai import ChatOpenAI
+from langchain_google_genai import ChatGoogleGenerativeAI
 from agents.base import BaseAgent
 
 class GoalSettingAgent(BaseAgent):
@@ -8,7 +8,7 @@ class GoalSettingAgent(BaseAgent):
     選手の情報と対話内容から、バッティング改善の大枠の目標を設定するエージェント。
     """
 
-    def __init__(self, llm: ChatOpenAI):
+    def __init__(self, llm: ChatGoogleGenerativeAI):
         super().__init__(llm)
         self.prompts = self._load_prompts()
 

--- a/agents/interactive_agent/agent.py
+++ b/agents/interactive_agent/agent.py
@@ -1,7 +1,7 @@
 from typing import Dict, Any, List, Optional
 import json
 import os
-from langchain_openai import ChatOpenAI
+from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_core.prompts import ChatPromptTemplate
 import streamlit as st
 
@@ -13,7 +13,7 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
 class InteractiveAgent(BaseAgent):
-    def __init__(self, llm: ChatOpenAI, mode: str = "mock"):
+    def __init__(self, llm: ChatGoogleGenerativeAI, mode: str = "mock"):
         super().__init__(llm)
         self.current_turn = 0
         self.max_turns = 3

--- a/agents/modeling_agent/agent.py
+++ b/agents/modeling_agent/agent.py
@@ -3,7 +3,7 @@ import json
 import os
 import asyncio
 import subprocess
-from langchain_openai import ChatOpenAI
+from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_core.prompts import ChatPromptTemplate
 
 from agents.base import BaseAgent
@@ -11,7 +11,7 @@ from agents.modeling_agent.metrics.swing import SwingMetrics
 from MotionAGFormer.JsonAnalist import analyze_json
 
 class ModelingAgent(BaseAgent):
-    def __init__(self, llm: ChatOpenAI, user_height: float = 170.0):
+    def __init__(self, llm: ChatGoogleGenerativeAI, user_height: float = 170.0):
         super().__init__(llm)
         self.swing_metrics = SwingMetrics()
         self.prompts = self._load_prompts()

--- a/agents/plan_agent/agent.py
+++ b/agents/plan_agent/agent.py
@@ -1,6 +1,6 @@
 import json
 from typing import Any, Dict, List
-from langchain_openai import ChatOpenAI
+from langchain_google_genai import ChatGoogleGenerativeAI
 from agents.base import BaseAgent
 from agents.search_agent.agent import SearchAgent
 
@@ -10,7 +10,7 @@ class PlanAgent(BaseAgent):
     必要に応じてSearchAgentで情報を収集し、再度プランに反映する。
     """
 
-    def __init__(self, llm: ChatOpenAI, search_agent: SearchAgent):
+    def __init__(self, llm: ChatGoogleGenerativeAI, search_agent: SearchAgent):
         super().__init__(llm)
         self.search_agent = search_agent
         self.prompts = self._load_prompts()

--- a/agents/search_agent/agent.py
+++ b/agents/search_agent/agent.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List
 import json
 import os
 from langchain_community.agent_toolkits.load_tools import load_tools
-from langchain_openai import ChatOpenAI
+from langchain_google_genai import ChatGoogleGenerativeAI
 from agents.base import BaseAgent
 
 class SearchAgent(BaseAgent):
@@ -10,7 +10,7 @@ class SearchAgent(BaseAgent):
     各種キーワードでGoogle検索を行い、その結果をPlanAgent等に提供するエージェント。
     """
 
-    def __init__(self, llm: ChatOpenAI):
+    def __init__(self, llm: ChatGoogleGenerativeAI):
         super().__init__(llm)
         # prepare search tools
         self.search_tools = load_tools(["google-search"])

--- a/agents/summarize_agent/agent.py
+++ b/agents/summarize_agent/agent.py
@@ -1,7 +1,7 @@
 from typing import Dict, Any, List
 import json
 import os
-from langchain_openai import ChatOpenAI
+from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_core.prompts import ChatPromptTemplate
 
 from agents.base import BaseAgent
@@ -12,7 +12,7 @@ class SummarizeAgent(BaseAgent):
     システム全体の出力を最終的なコーチングレポートにまとめる
     """
 
-    def __init__(self, llm: ChatOpenAI):
+    def __init__(self, llm: ChatGoogleGenerativeAI):
         super().__init__(llm)
         prompt_path = os.path.join(os.path.dirname(__file__), "prompts.json")
         with open(prompt_path, "r", encoding="utf-8") as f:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,1 +1,1 @@
-model_name: "gpt-4o"
+gemini_model_name: "gemini-2.5-flash"

--- a/core/cli/system.py
+++ b/core/cli/system.py
@@ -2,7 +2,7 @@ from typing import Dict, Any, Optional
 import os
 import json
 import asyncio
-from langchain_openai import ChatOpenAI
+from langchain_google_genai import ChatGoogleGenerativeAI
 from agents import (
     InteractiveAgent,
     ModelingAgent,
@@ -20,14 +20,15 @@ class SwingCoachingSystem:
         self.logger = SystemLogger()
 
         # LLMの初期化
-        openai_api_key = os.getenv("OPENAI_API_KEY")
-        if not openai_api_key:
-            raise ValueError("OPENAI_API_KEY environment variable is not set")
+        google_api_key = os.getenv("GOOGLE_API_KEY")
+        if not google_api_key:
+            raise ValueError("GOOGLE_API_KEY environment variable is not set")
 
-        self.llm = ChatOpenAI(
-            openai_api_key=openai_api_key,
-            model=config.get("model_name", "gpt-4"),
-            temperature=0.7
+        self.llm = ChatGoogleGenerativeAI(
+            google_api_key=google_api_key,
+            model=config.get("gemini_model_name", "gemini-2.5-flash"),
+            temperature=0.7,
+            convert_system_message_to_human=True
         )
 
         # エージェントの初期化

--- a/core/webui/system.py
+++ b/core/webui/system.py
@@ -2,7 +2,7 @@ from typing import Dict, Any, Optional, Tuple
 import os
 import asyncio
 import json
-from langchain_openai import ChatOpenAI
+from langchain_google_genai import ChatGoogleGenerativeAI
 
 from core.base.logger import SystemLogger
 from core.webui.state import WebUIState
@@ -24,14 +24,15 @@ class WebUISwingCoachingSystem:
         self.interactive_enabled = True
 
         # LLMの初期化
-        openai_api_key = os.getenv("OPENAI_API_KEY")
-        if not openai_api_key:
-            raise ValueError("OPENAI_API_KEY environment variable is not set")
+        google_api_key = os.getenv("GOOGLE_API_KEY")
+        if not google_api_key:
+            raise ValueError("GOOGLE_API_KEY environment variable is not set")
 
-        self.llm = ChatOpenAI(
-            openai_api_key=openai_api_key,
-            model=config.get("model_name", "gpt-4"),
-            temperature=0.7
+        self.llm = ChatGoogleGenerativeAI(
+            google_api_key=google_api_key,
+            model=config.get("gemini_model_name", "gemini-2.5-flash"),
+            temperature=0.7,
+            convert_system_message_to_human=True
         )
 
         # エージェントの初期化

--- a/main.py
+++ b/main.py
@@ -7,12 +7,12 @@ import asyncio
 from config.load_config import load_config
 from core.cli.system import SwingCoachingSystem
 from utils.json_handler import JSONHandler
-from langchain_openai import ChatOpenAI
+from langchain_google_genai import ChatGoogleGenerativeAI
 
-# .envを読み込む (OPENAI_API_KEYなど)
+# .envを読み込む (GOOGLE_API_KEYなど)
 load_dotenv(override=True)
 
-required_keys = ["OPENAI_API_KEY"]
+required_keys = ["GOOGLE_API_KEY"]
 for key in required_keys:
     if not os.getenv(key):
         raise ValueError(f"{key} environment variable is not set")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,13 +3,15 @@ streamlit>=1.32.0
 langchain>=0.1.0
 langchain-community>=0.0.16
 langchain-core>=0.1.17
-langchain-openai>=0.0.5
+# langchain-openai>=0.0.5
+langchain-google-genai
 langgraph>=0.0.10
 python-dotenv>=1.0.0
 pyyaml>=6.0.1
 
 # OpenAI and Other APIs
-openai>=1.12.0
+# openai>=1.12.0
+google-generativeai
 google-api-python-client>=2.0.0
 google-search-results>=2.4.2
 tavily-python>=0.3.1


### PR DESCRIPTION
## Summary
- replace ChatOpenAI with ChatGoogleGenerativeAI
- adjust config and main environment variables
- update requirements and README
- include `.env.example` for Google credentials
- fix README instructions

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686291a3733c8325b58d1500acace4ef